### PR TITLE
Pull request to fredpalmer/develop from fredpalmer/feature/extensionless-mime-typing

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -13,27 +13,35 @@ server {
     # e.g. http://<dims-host>/resize/100x100/http://media.parker.beetlebug.org/archive/2009/03/17/DSC_D300_1872.web.jpg
     listen   8080; ## listen for ipv4; this line is default and implied
     server_name _;
+    server_tokens off;
     log_subrequest on;
     rewrite_log on;
 
     # NOTE: this directory needs to have the permissions set to 777 so proxy_store will work correctly
-    root /mnt/media;
+    set $root_path /mnt/media;
+    root $root_path;
 
-    # Needed to allow uri protocol slashes from being merged
+    # Needed to allow requested image uri protocol slashes from being merged (used when proxying for source image)
     merge_slashes off;
 
     # Will proxy to external urls and gets remote images, the following will allow it to resolve properly
     resolver 8.8.8.8;  # Google DNS
 
+    # Allows us to respond to proxy redirects with things like error_page
     proxy_intercept_errors      on;
     proxy_pass_request_body     off;
     proxy_pass_request_headers  off;
+
+    # Hide Amazon Headers
+    proxy_hide_header           X-Amz-Id-2;
+    proxy_hide_header           X-Amz-Request-Id;
+
     # Need to also handle HEAD requests
     proxy_method                GET;
     proxy_temp_path             /tmp/images;
     proxy_store_access          user:rw  group:rw  all:r;
 
-    # This is the secret sauce to allow us to handle redirects with image uri's
+    # This is the secret sauce to allow us to handle proxy redirects with image uri's
     recursive_error_pages       on;
 
     # Sets the maximum size for images during a request
@@ -53,7 +61,7 @@ server {
         set $image_uri $4;
 
         # Use error_page to see if it's on disk, else try to generate it
-        error_page 404 = @process;
+        error_page 404 = @jpeg;
         log_not_found off;
     }
 
@@ -64,17 +72,59 @@ server {
         set $image_uri $2;
 
         # Use error_page to see if it's on disk, else try to generate it
-        error_page 404 = @process;
+        error_page 404 = @jpeg;
         log_not_found off;
+    }
+
+    # The named locations @jpeg, @png and @gif get evaluated in respective order for a file on disk.
+    # The repetition is necessary because try_files / error_page only allow redirection for the final
+    # fallback argument. These named locations clear mimetypes for this location and make the default
+    # type be the type of resource on disk.
+    #
+    # This is essentially a work-around to allow for extensionless assets to be stored on disk.
+    # The mimetype is being embedded in the path on disk by using the $upstream_http_content_type
+    # from the proxied source when specifying proxy_store
+    location @jpeg {
+        internal;
+        types           { }
+        default_type    image/jpeg;
+        root            $root_path/image/jpeg;
+        add_header      Dims-cached yes;
+        # Attempt to get it on disk, if not found move to the next named location
+        error_page 404 = @png;
+    }
+
+    location @png {
+        internal;
+        types           { }
+        default_type    image/png;
+        root            $root_path/image/png;
+        add_header      Dims-cached yes;
+        # Attempt to get it on disk, if not found move to the next named location
+        error_page 404 = @gif;
+    }
+
+    location @gif {
+        internal;
+        types           { }
+        default_type    image/gif;
+        root            $root_path/image/gif;
+        add_header      Dims-cached yes;
+
+        # Finally if there is no jpeg, png or gif of the requested uri on disk then we proceed to attempt to
+        # get it from the image uri requested in the last part of the path of the request
+        error_page 404 = @process;
     }
 
     location @process {
         internal;
-        # Store the image in proxy storage for later retrievals (using $request_uri intentionally)
-        proxy_store                 $document_root$request_uri;
+        add_header Dims-cached no;
 
         # Generate the image if it doesn't exist
         proxy_pass http://127.0.0.1:8080/internal/$command?uri=$image_uri&arg1=$arg1&arg2=$arg2;
+
+        # Store the image in proxy storage for later retrievals (using $request_uri intentionally)
+        proxy_store                 $document_root/$upstream_http_content_type/$request_uri;
     }
 
     location @process_redirect {


### PR DESCRIPTION
Please pull these commits into fredpalmer/develop.  Here is the latest commit message:

_"Added the ability to store extensionless assets but still serve the correct mimetype - only works for jpeg, gif and png"_
