### PR TITLE
Changed from $request_uri to $uri when writing the file using proxy_store

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -123,8 +123,8 @@ server {
         # Generate the image if it doesn't exist
         proxy_pass http://127.0.0.1:8080/internal/$command?uri=$image_uri&arg1=$arg1&arg2=$arg2;
 
-        # Store the image in proxy storage for later retrievals (using $request_uri intentionally)
-        proxy_store                 $document_root/$upstream_http_content_type/$request_uri;
+        # Store the image in proxy storage for later retrievals (using $uri as filename which is urldecoded but lacks $args)
+        proxy_store                 $document_root/$upstream_http_content_type/$uri;
     }
 
     location @process_redirect {


### PR DESCRIPTION
The reason is that $uri is unescaped and when serving the file from file cache, the url is unsescaped as well so the url "/image%20data/file.jpg" will be written as /image%20data/file.jpg in proxy_store but accessed as /image data/file.jpg when serving the request from file cache.
